### PR TITLE
Options workaround for Update 1.3.0

### DIFF
--- a/scripts/ui/settings-init.js
+++ b/scripts/ui/settings-init.js
@@ -17,6 +17,15 @@ const onOptionColorfulUpdate = (optionInfo, value) => {
     PolicyYieldsSettings.IsColorful = value;
 }
 
+// fix Options initialization
+Options.addInitCallback = function(callback) {
+    if (this.optionsReInitCallbacks.length && !this.optionsInitCallbacks.length) {
+        throw new Error("Options already initialized, cannot add init callback");
+    }
+    this.optionsInitCallbacks.push(callback);
+    this.optionsReInitCallbacks.push(callback);
+}
+
 Options.addInitCallback(() => {
     Options.addOption({ 
         category: CategoryType["Mods"], 


### PR DESCRIPTION
Update 1.3.0 changed the Options screen and broke custom option callbacks.
this patches the `Options.addInitCallback` method to work around the problem.